### PR TITLE
GitHub Action: Publish

### DIFF
--- a/.github/actions/number-version-information/action.yml
+++ b/.github/actions/number-version-information/action.yml
@@ -1,0 +1,82 @@
+name: Number version information
+
+description: Provides number version
+
+outputs:
+  major:
+    value: ${{ steps.tag-version.outputs.major }}
+  minor:
+    value: ${{ steps.tag-version.outputs.minor }}
+  patch:
+    value: ${{ steps.tag-version.outputs.patch }}
+  build:
+    value: ${{ steps.action-context.outputs.build }}
+  attempt:
+    value: ${{ steps.action-context.outputs.attempt }}
+  today:
+    value: ${{ steps.action-context.outputs.today }}
+  revision:
+    value: ${{ steps.commit.outputs.revision }}
+  suffix:
+    value: ${{ steps.tag-version.outputs.suffix }}
+  version-short:
+    value: ${{ steps.format.outputs.short }}
+  version-full:
+    value: ${{ steps.format.outputs.full }}
+
+runs:
+  using: "composite"
+
+  steps:
+    - id: tag-version
+      shell: bash
+      run: |
+        regex="v([0-9]+)\.?([0-9]*)\.?([0-9]*)[^a-zA-Z]?(.*)"
+        version=$(git describe --tags --abbrev=0 --match "v[0-9]*" --always)
+
+        echo "tag: $version"
+
+        if [[ $version =~ $regex ]]; then
+          major=${BASH_REMATCH[1]}
+          minor=${BASH_REMATCH[2]}
+          patch=${BASH_REMATCH[3]}
+          suffix=${BASH_REMATCH[4]}
+        else
+          major=0
+          minor=1
+        fi
+
+        echo "major=$([[ -z $major ]] && echo 1 || echo $major)" >> $GITHUB_OUTPUT
+        echo "minor=$([[ -z $minor ]] && echo 0 || echo $minor)" >> $GITHUB_OUTPUT
+        echo "patch=$([[ -z $patch ]] && echo 0 || echo $patch)" >> $GITHUB_OUTPUT
+        echo "suffix=$([[ -z $suffix ]] && echo '' || echo $suffix)" >> $GITHUB_OUTPUT
+
+    - id: commit
+      shell: bash
+      run: |
+        echo "revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+    - id: action-context
+      shell: bash
+      run: |
+        echo "today=$(date -u "+%y%m%d")" >> $GITHUB_OUTPUT
+        echo "build=${{ github.run_number }}" >> $GITHUB_OUTPUT
+        echo "attempt=${{ github.run_attempt }}" >> $GITHUB_OUTPUT
+
+    - id: format
+      shell: bash
+      run: |
+        suffix=${{ env.suffix }}
+        suffix=$([[ -z $suffix ]] && echo '' || echo "-${suffix##*(-)}")
+
+        echo "short=$(echo ${{ env.major }}.${{ env.minor }}.${{ env.patch }}.${{ env.build }})" >> $GITHUB_OUTPUT
+        echo "full=$(echo ${{ env.major }}.${{ env.minor }}.${{ env.patch }}.${{ env.build }}-${{ env.today }}+${{ env.revision }}$suffix)" >> $GITHUB_OUTPUT
+      env:
+        major: ${{ steps.tag-version.outputs.major }}
+        minor: ${{ steps.tag-version.outputs.minor }}
+        patch: ${{ steps.tag-version.outputs.patch }}
+        build: ${{ steps.action-context.outputs.build }}
+        today: ${{ steps.action-context.outputs.today }}
+        attempt: ${{ steps.action-context.outputs.attempt }}
+        revision: ${{ steps.commit.outputs.revision }}
+        suffix: ${{ steps.tag-version.outputs.suffix }}

--- a/.github/actions/publish-config-parser/action.yml
+++ b/.github/actions/publish-config-parser/action.yml
@@ -1,0 +1,34 @@
+name: Publish configuration parser.
+
+description: It parses json configuration file which contains publish profiles. It can also select profiles by tags.
+
+inputs:
+  config-file:
+    type: string
+    required: true
+  tags:
+    type: string
+    default: ''
+
+outputs:
+  project-file:
+    value: ${{ steps.parse.outputs.project-file }}
+  output-name:
+    value: ${{ steps.parse.outputs.output-name }}
+  profiles:
+    value: ${{ steps.parse.outputs.profiles }}
+
+runs:
+  using: "composite"
+
+  steps:
+    - id: parse
+      shell: bash
+      run: |
+        config=${{ inputs.config-file }}
+
+        echo "project-file=$(jq -r ' ."project-file" ' $config )" >> $GITHUB_OUTPUT
+        echo "output-name=$(jq -r ' ."output-name" ' $config )" >> $GITHUB_OUTPUT
+
+        profiles=$(jq -r --arg tags "${{ inputs.tags }}" '($tags / ",") as $tags | [ .profiles[] | (.tags) as $profile_tags | select(all($tags[]; IN($profile_tags[]))) | {os,runtime,configuration,framework,options} ]' $config)
+        echo "profiles={\"include\":$(echo $profiles)}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,6 @@
 # This workflow will build and test the project
 
-name: build and test
+name: Build and Test
 
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,136 @@
+# This workflow will publish the project
+
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      config-file:
+        type: string
+        default: "./publish/config.json"
+
+      target-os:
+        type: choice
+        default: all
+        options: 
+        - windows
+        - linux
+        - macos
+        - all
+
+      target-runtime:
+        type: choice
+        default: all
+        options: 
+        - x86
+        - x64
+        - arm
+        - arm64
+        - all
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.publish-config-parser.outputs.profiles }}
+      status: ${{ steps.checker.outputs.status }}
+      project-file: ${{ steps.publish-config-parser.outputs.project-file }}
+      output-name: ${{ steps.publish-config-parser.outputs.output-name }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Parse configuration
+      id: publish-config-parser
+      uses: ./.github/actions/publish-config-parser
+      with:
+        config-file: ${{ github.event.inputs.config-file }}
+        tags: "${{ github.event.inputs.target-os }},${{ github.event.inputs.target-runtime }}"
+
+    - name: Check profiles
+      id: checker
+      run: |
+        profiles='${{ steps.publish-config-parser.outputs.profiles }}'
+        length=$( echo $profiles | jq '.include | length' )
+
+        if(( $length > 0 )); then
+           echo "status=success" >> $GITHUB_OUTPUT
+         else
+           echo "status=failure" >> $GITHUB_OUTPUT
+           echo "No suitable publish profile found"
+         fi
+    
+  publish:
+    name: Publish
+    needs: prepare
+    if: needs.prepare.outputs.status == 'success'
+    
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{fromJson(needs.prepare.outputs.matrix)}}
+
+    env:
+      output-name: ${{ needs.prepare.outputs.output-name }}
+      project-file: ${{ needs.prepare.outputs.project-file }}
+      configuration: ${{ matrix.configuration }}
+      framework: ${{ matrix.framework }}
+      runtime: ${{ matrix.runtime }}
+      publish-options: ${{ matrix.options }}
+      output-root: publish/output
+
+      # template: root/configuration/framework/runtime
+      output-template: '{0}/{1}/{2}/{3}'
+      
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Install .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
+    
+    - name: Calculate version
+      id: number-version-information
+      uses: ./.github/actions/number-version-information
+
+    - name: New version
+      run: | 
+        echo "Short version: ${{ steps.number-version-information.outputs.version-short }}"
+        echo "Full version: ${{ steps.number-version-information.outputs.version-full }}"
+        echo "Major: ${{ steps.number-version-information.outputs.major }}"
+        echo "Minor: ${{ steps.number-version-information.outputs.minor }}"
+        echo "Patch: ${{ steps.number-version-information.outputs.patch }}"
+        echo "Build: ${{ steps.number-version-information.outputs.build }}"
+        echo "Attempt: ${{ steps.number-version-information.outputs.attempt }}"
+        echo "Today: ${{ steps.number-version-information.outputs.today }}"
+        echo "Revision: ${{ steps.number-version-information.outputs.revision }}"
+        echo "Suffix: ${{ steps.number-version-information.outputs.suffix }}"
+
+    - name: Publish ${{ env.output-name }} [${{ env.version-short }}]
+      run: |
+        dotnet publish "${{ env.project-file }}" --output "${{ env.output }}" --configuration "${{ env.configuration }}" --framework "${{ env.framework }}" --runtime "${{ env.runtime }}" --property:Version="${{ env.version-full }}" ${{ env.publish-options }} 
+      env:
+        output: "${{ format(env.output-template, env.output-root, env.configuration, env.framework, env.runtime) }}"
+        version-full: "${{ steps.number-version-information.outputs.version-full }}"
+        version-short: "${{ steps.number-version-information.outputs.version-short }}"
+
+    - name: Archive artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: "${{ env.output-name }} [${{ env.version-short }}]"
+        path: |
+          ${{ env.output }}
+          !${{ env.output }}/**/*.pdb
+      env:
+        artifact-name: "${{ env.output-name }}"
+        version-short: "${{ steps.number-version-information.outputs.version-short }}"
+        output: "${{ env.output-root }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,7 +129,6 @@ jobs:
         name: "${{ env.output-name }} [${{ env.version-short }}]"
         path: |
           ${{ env.output }}
-          !${{ env.output }}/**/*.pdb
       env:
         artifact-name: "${{ env.output-name }}"
         version-short: "${{ steps.number-version-information.outputs.version-short }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 
-    - name: Parse configuration
+    - name: Parse configuration "${{ github.event.inputs.config-file }}"
       id: publish-config-parser
       uses: ./.github/actions/publish-config-parser
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/Eppie.CLI/Eppie.CLI/bin/
 src/Eppie.CLI/Eppie.CLI/obj/
 src/Eppie.CLI/Eppie.CLI/logs/
 src/Eppie.CLI/Eppie.CLI/Eppie.CLI.csproj.user
+publish/output/

--- a/publish/config.json
+++ b/publish/config.json
@@ -1,0 +1,88 @@
+{
+  "project-file": "src/Eppie.CLI/Eppie.CLI/Eppie.CLI.csproj",
+  "output-name": "Eppie.CLI",
+
+  "profiles" :
+  [
+    {
+      "tags": ["windows", "x86", "all"],
+      "os": "windows-latest",
+      "runtime": "win-x86",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+    },
+
+    {
+      "tags": ["windows", "x64", "all"],
+      "os": "windows-latest",
+      "runtime": "win-x64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+    },
+
+    {
+      "tags": ["windows", "arm", "all"],
+      "os": "windows-latest",
+      "runtime": "win-arm",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+    },
+
+    {
+      "tags": ["windows", "arm64", "all"],
+      "os": "windows-latest",
+      "runtime": "win-arm64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+    },
+
+    {
+      "tags": ["linux", "x64", "all"],
+      "os": "ubuntu-latest",
+      "runtime": "linux-x64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+    },
+
+    {
+      "tags": ["linux", "arm", "all"],
+      "os": "ubuntu-latest",
+      "runtime": "linux-arm",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+    },
+
+    {
+      "tags": ["linux", "arm64", "all"],
+      "os": "ubuntu-latest",
+      "runtime": "linux-arm64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+    },
+
+    {
+      "tags": ["macos", "x64", "all"],
+      "os": "macos-latest",
+      "runtime": "osx-x64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"      
+    },
+
+    {
+      "tags": ["macos", "arm64", "all"],
+      "os": "macos-latest",
+      "runtime": "osx-arm64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"      
+    }
+  ]
+}

--- a/publish/config.json
+++ b/publish/config.json
@@ -10,7 +10,7 @@
       "runtime": "win-x86",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=false --property:PublishReadyToRun=true"
     },
 
     {
@@ -19,7 +19,7 @@
       "runtime": "win-x64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=false --property:PublishReadyToRun=true"
     },
 
     {
@@ -28,7 +28,7 @@
       "runtime": "win-arm",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=false --property:PublishReadyToRun=true"
     },
 
     {
@@ -37,7 +37,7 @@
       "runtime": "win-arm64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=false --property:PublishReadyToRun=true"
     },
 
     {
@@ -46,7 +46,7 @@
       "runtime": "linux-x64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=false --property:PublishReadyToRun=true"
     },
 
     {
@@ -55,7 +55,7 @@
       "runtime": "linux-arm",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=false --property:PublishReadyToRun=true"
     },
 
     {
@@ -64,7 +64,7 @@
       "runtime": "linux-arm64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=false --property:PublishReadyToRun=true"
     },
 
     {
@@ -73,7 +73,7 @@
       "runtime": "osx-x64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"      
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=false --property:PublishReadyToRun=true"      
     },
 
     {
@@ -82,7 +82,7 @@
       "runtime": "osx-arm64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:PublishReadyToRun=true"      
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=false --property:PublishReadyToRun=true"      
     }
   ]
 }

--- a/publish/config.options-off.json
+++ b/publish/config.options-off.json
@@ -10,7 +10,7 @@
       "runtime": "win-x86",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:DebugType=None"
     },
 
     {
@@ -19,7 +19,7 @@
       "runtime": "win-x64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:DebugType=None"
     },
 
     {
@@ -28,7 +28,7 @@
       "runtime": "win-arm",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:DebugType=None"
     },
 
     {
@@ -37,7 +37,7 @@
       "runtime": "win-arm64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:DebugType=None"
     },
 
     {
@@ -46,7 +46,7 @@
       "runtime": "linux-x64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:DebugType=None"
     },
 
     {
@@ -55,7 +55,7 @@
       "runtime": "linux-arm",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:DebugType=None"
     },
 
     {
@@ -64,7 +64,7 @@
       "runtime": "linux-arm64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:DebugType=None"
     },
 
     {
@@ -73,7 +73,7 @@
       "runtime": "osx-x64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"      
+      "options" : "--self-contained --property:DebugType=None"
     },
 
     {
@@ -82,7 +82,7 @@
       "runtime": "osx-arm64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"      
+      "options" : "--self-contained --property:DebugType=None"
     }
   ]
 }

--- a/publish/config.options-on.json
+++ b/publish/config.options-on.json
@@ -1,0 +1,88 @@
+{
+  "project-file": "src/Eppie.CLI/Eppie.CLI/Eppie.CLI.csproj",
+  "output-name": "Eppie.CLI",
+
+  "profiles" :
+  [
+    {
+      "tags": ["windows", "x86", "all"],
+      "os": "windows-latest",
+      "runtime": "win-x86",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:PublishReadyToRun=true --property:DebugType=None"
+    },
+
+    {
+      "tags": ["windows", "x64", "all"],
+      "os": "windows-latest",
+      "runtime": "win-x64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:PublishReadyToRun=true --property:DebugType=None"
+    },
+
+    {
+      "tags": ["windows", "arm", "all"],
+      "os": "windows-latest",
+      "runtime": "win-arm",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:PublishReadyToRun=true --property:DebugType=None"
+    },
+
+    {
+      "tags": ["windows", "arm64", "all"],
+      "os": "windows-latest",
+      "runtime": "win-arm64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:PublishReadyToRun=true --property:DebugType=None"
+    },
+
+    {
+      "tags": ["linux", "x64", "all"],
+      "os": "ubuntu-latest",
+      "runtime": "linux-x64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:PublishReadyToRun=true --property:DebugType=None"
+    },
+
+    {
+      "tags": ["linux", "arm", "all"],
+      "os": "ubuntu-latest",
+      "runtime": "linux-arm",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:PublishReadyToRun=true --property:DebugType=None"
+    },
+
+    {
+      "tags": ["linux", "arm64", "all"],
+      "os": "ubuntu-latest",
+      "runtime": "linux-arm64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:PublishReadyToRun=true --property:DebugType=None"
+    },
+
+    {
+      "tags": ["macos", "x64", "all"],
+      "os": "macos-latest",
+      "runtime": "osx-x64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:PublishReadyToRun=true --property:DebugType=None"      
+    },
+
+    {
+      "tags": ["macos", "arm64", "all"],
+      "os": "macos-latest",
+      "runtime": "osx-arm64",
+      "configuration": "release",
+      "framework": "net7.0",
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:PublishReadyToRun=true --property:DebugType=None"      
+    }
+  ]
+}

--- a/publish/config.trim-off.json
+++ b/publish/config.trim-off.json
@@ -10,7 +10,7 @@
       "runtime": "win-x86",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishReadyToRun=true --property:DebugType=None"
     },
 
     {
@@ -19,7 +19,7 @@
       "runtime": "win-x64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishReadyToRun=true --property:DebugType=None"
     },
 
     {
@@ -28,7 +28,7 @@
       "runtime": "win-arm",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishReadyToRun=true --property:DebugType=None"
     },
 
     {
@@ -37,7 +37,7 @@
       "runtime": "win-arm64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishReadyToRun=true --property:DebugType=None"
     },
 
     {
@@ -46,7 +46,7 @@
       "runtime": "linux-x64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishReadyToRun=true --property:DebugType=None"
     },
 
     {
@@ -55,7 +55,7 @@
       "runtime": "linux-arm",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishReadyToRun=true --property:DebugType=None"
     },
 
     {
@@ -64,7 +64,7 @@
       "runtime": "linux-arm64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishReadyToRun=true --property:DebugType=None"
     },
 
     {
@@ -73,7 +73,7 @@
       "runtime": "osx-x64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"      
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishReadyToRun=true --property:DebugType=None"      
     },
 
     {
@@ -82,7 +82,7 @@
       "runtime": "osx-arm64",
       "configuration": "release",
       "framework": "net7.0",
-      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishTrimmed=true --property:TrimMode=partial --property:DebugType=None"      
+      "options" : "--self-contained --property:PublishSingleFile=true --property:PublishReadyToRun=true --property:DebugType=None"      
     }
   ]
 }

--- a/src/Eppie.CLI/Eppie.CLI/Eppie.CLI.csproj
+++ b/src/Eppie.CLI/Eppie.CLI/Eppie.CLI.csproj
@@ -7,14 +7,19 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>6.0-all</AnalysisLevel>
     <NeutralLanguage>en</NeutralLanguage>
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <WarningLevel>9999</WarningLevel>
+    <WarningsNotAsErrors>IL2104</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <WarningLevel>9999</WarningLevel>
+    <WarningsNotAsErrors>IL2104</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -46,11 +51,13 @@
   <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <TargetPath>appsettings.json</TargetPath>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </None>
     <None Update="appsettings.Development.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <TargetPath>appsettings.Development.json</TargetPath>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </None>
   </ItemGroup>
 

--- a/src/Eppie.CLI/Eppie.CLI/Program.cs
+++ b/src/Eppie.CLI/Eppie.CLI/Program.cs
@@ -30,7 +30,7 @@ namespace Eppie.CLI
 
         static async Task Main(string[] args)
         {
-            Host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args)
+            Host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args).UseContentRoot(AppContext.BaseDirectory)
                 .ConfigureServices((context, services) =>
                 {
                     services.AddLocalization()

--- a/src/Eppie.CLI/Eppie.CLI/appsettings.Development.json
+++ b/src/Eppie.CLI/Eppie.CLI/appsettings.Development.json
@@ -1,5 +1,15 @@
 {
   "Serilog": {
+    "Using": [
+      "Serilog.Enrichers.Environment",
+      "Serilog.Enrichers.Process",
+      "Serilog.Enrichers.Thread",
+      "Serilog.Formatting.Compact",
+      "Serilog.Sinks.Async",
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.Debug",
+      "Serilog.Sinks.File"
+    ],
     "MinimumLevel": {
       "Default": "Verbose",
       "Override": {

--- a/src/Eppie.CLI/Eppie.CLI/appsettings.json
+++ b/src/Eppie.CLI/Eppie.CLI/appsettings.json
@@ -4,6 +4,16 @@
     "Encoding": "utf-8"
   },
   "Serilog": {
+    "Using": [
+      "Serilog.Enrichers.Environment",
+      "Serilog.Enrichers.Process",
+      "Serilog.Enrichers.Thread",
+      "Serilog.Formatting.Compact",
+      "Serilog.Sinks.Async",
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.Debug",
+      "Serilog.Sinks.File"
+    ],
     "MinimumLevel": {
       "Default": "Debug",
       "Override": {


### PR DESCRIPTION
It can publish on linux, macos, windows with x86, x64, arm, arm64.

It can read version from git tags. 
Tag format `v<major>[.minor][.patch][-suffix]`:  v1; v1.1; v1.2.4; v1.0.0-beta.
App short number version `major.minor.patch.build`: 1.0.1.56
App full version `major.minor.patch.build-yyMMdd+gitrev[-suffix]`: 1.3.5.26-230531+7c9e9b4; 1.0.1.56-231231+945ac01-beta.

Now it can only be started manually.

