### PR TITLE
'Build project' readme section

### DIFF
--- a/BUILDS.md
+++ b/BUILDS.md
@@ -2,14 +2,14 @@
 
 ## Prerequisites
 
-- .NET 7.0 [download](https://dotnet.microsoft.com/en-us/download)
+- [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 
 ## Build
 
 To build the **Eppie.CLI** project, run the following command in the project root directory:
 
 ```console
-dotnet build .\src\Eppie.CLI\
+dotnet build ./src/Eppie.CLI/
 ```
 
 ### How to build with forked submodules
@@ -34,12 +34,12 @@ To build the project with your own forked submodules, you have to add the follow
     insteadOf = https://github.com/Eppie-io/<REPOSITORY-NAME>.git
 ```
 
-## Launches
+## Launch
 
 To launch **Eppie Console** application, you can run the following command:
 
 ```console
-dotnet run --project .\src\Eppie.CLI\Eppie.CLI\Eppie.CLI.csproj
+dotnet run --project ./src/Eppie.CLI/Eppie.CLI/Eppie.CLI.csproj
 ```
 
 ### Environment
@@ -47,7 +47,7 @@ dotnet run --project .\src\Eppie.CLI\Eppie.CLI\Eppie.CLI.csproj
 To change the default environment configuration to some custom configuration, run the command with the arguments `--ENVIRONMENT=<environment-name>`:
 
 ```console
-dotnet run --project .\src\Eppie.CLI\Eppie.CLI\Eppie.CLI.csproj -- --ENVIRONMENT=Development
+dotnet run --project ./src/Eppie.CLI/Eppie.CLI/Eppie.CLI.csproj -- --ENVIRONMENT=Development
 ```
 
 - The default environment is **Production**. The location of the configuration file is *.\src\Eppie.CLI\Eppie.CLI\appsettings.json*.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![StaticBadge](https://img.shields.io/badge/version-Alpha-lightgrey)
 [![StaticBadge](https://img.shields.io/github/license/Eppie-io/Eppie-CLI.svg)](https://raw.githubusercontent.com/Eppie-io/Eppie-CLI/main/LICENSE)
-![StaticBadge](https://img.shields.io/badge/Linux-red?logo=linux&logoColor=white)
+![StaticBadge](https://img.shields.io/badge/Linux-gold?logo=linux&logoColor=black)
 ![StaticBadge](https://img.shields.io/badge/macOS-black?logo=apple)
 ![StaticBadge](https://img.shields.io/badge/Windows-blue?logo=windows)
 [![Crowdin](https://badges.crowdin.net/e/8fee200a40ee70ffd3fa6b7d8d23deee/localized.svg)](https://eppie.crowdin.com/eppie)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Command line client for Eppie &#8212; an encrypted p2p email
 
 ![StaticBadge](https://img.shields.io/badge/version-Alpha-lightgrey)
-![StaticBadge](https://img.shields.io/badge/licence-Apache--2.0-green)
-![StaticBadge](https://img.shields.io/badge/Linux-red?logo=linux)
+[![StaticBadge](https://img.shields.io/github/license/Eppie-io/Eppie-CLI.svg)](https://raw.githubusercontent.com/Eppie-io/Eppie-CLI/main/LICENSE)
+![StaticBadge](https://img.shields.io/badge/Linux-red?logo=linux&logoColor=white)
 ![StaticBadge](https://img.shields.io/badge/macOS-black?logo=apple)
 ![StaticBadge](https://img.shields.io/badge/Windows-blue?logo=windows)
 [![Crowdin](https://badges.crowdin.net/e/8fee200a40ee70ffd3fa6b7d8d23deee/localized.svg)](https://eppie.crowdin.com/eppie)
@@ -32,9 +32,35 @@ The decentralized protoccol is still in development and its features are not yet
 - Viewing a single message
 - Writing & sending messages
 
-## Build
+## Build project
 
-WIP
+### Prerequisites
+
+- [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+
+### Clone
+
+First of all, clone the project repository to your machine:
+
+```console
+git clone --recursive https://github.com/Eppie-io/Eppie-CLI.git eppie-cli
+```
+
+### Build
+
+To build the **Eppie.CLI** project, run the following command in the project root directory:
+
+```console
+dotnet build ./src/Eppie.CLI/
+```
+
+### Launch
+
+To launch **Eppie Console** application, you can run the following command:
+
+```console
+dotnet run --project ./src/Eppie.CLI/Eppie.CLI/Eppie.CLI.csproj
+```
 
 ## Available commands
 


### PR DESCRIPTION
Change README.md

- added `Build project` section.
- fix license badge
- fix linux logo color Change BUILDS.md

Change BUILDS.md
- corrected link to .net installer
- corrected project paths