### PR TITLE
fix: enable longpaths option

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,6 +67,10 @@ jobs:
       configuration: ${{ matrix.configuration }}
 
     steps:
+    - name: Support longpaths
+      if: ${{ matrix.os == 'windows-latest'}}
+      run: git config --system core.longpaths true
+
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,6 +113,10 @@ jobs:
       output-path: '.publish/output/bin/${{ matrix.configuration }}/${{ matrix.framework }}/${{ matrix.runtime }}'
 
     steps:
+    - name: Support longpaths
+      if: ${{ matrix.os == 'windows-latest'}}
+      run: git config --system core.longpaths true
+
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:


### PR DESCRIPTION
# Description

Enable the **longpaths** git option on Windows OS

## Related issue

Close: Eppie-io/Eppie-CLI#260

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Doc update

## Needs Follow Up Actions

- [ ] New release
