### PR TITLE
fix: Move all hardcoded strings to resources

### DIFF
--- a/src/Eppie.CLI/Eppie.CLI/Menu/Actions.cs
+++ b/src/Eppie.CLI/Eppie.CLI/Menu/Actions.cs
@@ -359,10 +359,7 @@ namespace Eppie.CLI.Menu
             }
             catch (OperationCanceledException)
             {
-                //ToDo: Move string to resources
-#pragma warning disable CA1303 // Retrieve the following string(s) from a resource table.
-                Console.WriteLine("Authorization operation has been canceled.");
-#pragma warning restore CA1303
+                _application.WriteAuthorizationCanceledMessage();
             }
         }
 
@@ -401,16 +398,14 @@ namespace Eppie.CLI.Menu
 
                 IAuthorizationClient authClient = _authProvider.CreateAuthorizationClient(mailServer);
 
-                //ToDo: Move string to resources
-                Console.WriteLine($"Authorization to {mailServer} service. Press Ctrl+C to cancel the operation.");
+                _application.WriteAuthorizationToServiceMessage(mailServer.ToString());
                 AuthCredential authCredential = await authClient.LoginAsync(cancellationLogin.Token).ConfigureAwait(false);
 
                 string? email = await ReadEmailAddressAsync(authClient, authCredential).ConfigureAwait(false);
 
                 if (!string.IsNullOrEmpty(email))
                 {
-                    //ToDo: Move string to resources
-                    Console.WriteLine($"Authorization of account '{email}' completed successfully.");
+                    _application.WriteAuthorizationCompletedMessage();
 
                     Account account = Account.Default;
                     account.Email = new EmailAddress(email);

--- a/src/Eppie.CLI/Eppie.CLI/Resources/Program.resx
+++ b/src/Eppie.CLI/Eppie.CLI/Resources/Program.resx
@@ -442,6 +442,10 @@
     <comment>This message prompts the user to select one of the options.
 {0} is the parameter containing the default option.</comment>
   </data>
+  <data name="Message.AuthorizationCanceled" xml:space="preserve">
+    <value>Authorization operation has been canceled.</value>
+    <comment>This message informs the user that the authorization operation was canceled.</comment>
+  </data>
   <data name="Message.SelectOptionHeader" xml:space="preserve">
     <value>Please select which option you want:</value>
     <comment>Header text for the list of options that the user is asked to select.</comment>
@@ -468,5 +472,14 @@
     <value> (default is {0})</value>
     <comment>This is the text template for the default server address.
 {0} is a parameter containing the default server address.</comment>
+  </data>
+  <data name="Message.AuthorizationToService" xml:space="preserve">
+    <value>Authorization to {0} service. Press Ctrl+C to cancel the operation.</value>
+    <comment>This message informs the user that authorization to a service is starting.
+{0} is a parameter containing the service name.</comment>
+  </data>
+  <data name="Message.AuthorizationCompleted" xml:space="preserve">
+    <value>Authorization completed successfully.</value>
+    <comment>This message informs the user that authorization was completed successfully.</comment>
   </data>
 </root>

--- a/src/Eppie.CLI/Eppie.CLI/Services/Application.cs
+++ b/src/Eppie.CLI/Eppie.CLI/Services/Application.cs
@@ -308,6 +308,24 @@ namespace Eppie.CLI.Services
             Console.WriteLine(_resourceLoader.Strings.AppRestored);
         }
 
+        internal void WriteAuthorizationCanceledMessage()
+        {
+            _logger.LogDebug("Authorization operation was canceled.");
+            Console.WriteLine(_resourceLoader.Strings.AuthorizationCanceled);
+        }
+
+        internal void WriteAuthorizationToServiceMessage(string serviceName)
+        {
+            _logger.LogDebug("Authorization to {ServiceName} service starting.", serviceName);
+            Console.WriteLine(_resourceLoader.Strings.GetAuthorizationToServiceText(serviceName));
+        }
+
+        internal void WriteAuthorizationCompletedMessage()
+        {
+            _logger.LogDebug("Authorization completed successfully.");
+            Console.WriteLine(_resourceLoader.Strings.AuthorizationCompleted);
+        }
+
         internal void WriteInvalidPasswordWarning()
         {
             LogCommandWarning("Invalid Password");

--- a/src/Eppie.CLI/Eppie.CLI/Services/ResourceLoader.cs
+++ b/src/Eppie.CLI/Eppie.CLI/Services/ResourceLoader.cs
@@ -153,6 +153,12 @@ namespace Eppie.CLI.Services
             private string? _askMessageBody;
             internal string AskMessageBody => _askMessageBody ??= _localizer.LoadString(GetStringResourceName());
 
+            private string? _authorizationCanceled;
+            internal string AuthorizationCanceled => _authorizationCanceled ??= _localizer.LoadString(GetStringResourceName());
+
+            private string? _authorizationCompleted;
+            internal string AuthorizationCompleted => _authorizationCompleted ??= _localizer.LoadString(GetStringResourceName());
+
             private string? _invalidPassword;
             internal string InvalidPassword => _invalidPassword ??= _localizer.LoadString(GetStringResourceName(category: "Warning"));
 
@@ -343,6 +349,11 @@ namespace Eppie.CLI.Services
             internal string GetAskOptionText(string defaultOption)
             {
                 return _localizer.LoadFormattedString(GetStringResourceName(name: "AskOption"), defaultOption);
+            }
+
+            internal string GetAuthorizationToServiceText(string serviceName)
+            {
+                return _localizer.LoadFormattedString(GetStringResourceName(name: "AuthorizationToService"), serviceName);
             }
 
             private static string GetStringResourceName(string category = "Message", [CallerMemberName] string name = "")


### PR DESCRIPTION
# Description

<!--Please add a summary of the change here.
Please also add other related information/contexts/dependencies here.
-->
* Fix CA1303: Move "Authorization operation has been canceled." to resources
* Fix CA1303: Move all remaining hardcoded strings to resources
* Remove email exposure from authorization completed log message
* Remove email exposure from entire authorization completed flow
* Remove GetAuthorizationCompletedText method and replace with direct property access

## Related issue

<!--Please add the related issue link(s) below.-->
- Eppie-io/Eppie-CLI#108

## Type of Change

- [x] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Doc update

## Needs Follow Up Actions

- [ ] New release
