### PR TITLE
fix: Add DEBUG conditional compilation to sensitive data masking operators

### DIFF
--- a/src/Eppie.CLI/Eppie.CLI/Program.cs
+++ b/src/Eppie.CLI/Eppie.CLI/Program.cs
@@ -19,7 +19,9 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
+#if DEBUG
 using Eppie.CLI.Logging;
+#endif
 using Eppie.CLI.Menu;
 using Eppie.CLI.Options;
 using Eppie.CLI.Services;
@@ -92,12 +94,14 @@ namespace Eppie.CLI
                 {
                     options.Mode = MaskingMode.Globally;
 
+#if DEBUG
                     options.MaskingOperators =
                     [
                         new HashTransformOperator<EmailAddressMaskingOperator>(),
                         new HashTransformOperator<IbanMaskingOperator>(),
                         new HashTransformOperator<CreditCardMaskingOperator>()
                     ];
+#endif
                 })
                 .WriteTo.Console(restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Fatal,
                                  formatProvider: CultureInfo.InvariantCulture)


### PR DESCRIPTION
# Description

<!--Please add a summary of the change here.
Please also add other related information/contexts/dependencies here.
-->
* Add DEBUG conditional compilation to MaskingOperators in ConfigureDefaultLogger
* Fix Release build by adding conditional compilation to using directive for Eppie.CLI.Logging

## Related issue
N/A

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Doc update

## Needs Follow Up Actions

- [ ] New release
