### PR TITLE
docs: add agent automation guide and test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ You might find Eppie-CLI interesting if
 
 In any case you are very welcome to fork, build and explore this module to your heart's content (see instructions below).
 
+## AI agent skill
+
+If you want to use `eppie-console` from an AI agent or automation workflow, see:
+
+- [docs/eppie-cli-agent-skill.md](docs/eppie-cli-agent-skill.md)
+
 ## Features
 
 The decentralized protoccol is still in development and its features are not yet available in Eppie-CLI. Meanwhile Eppie works as a conventional CLI email client with additional security features:
@@ -150,22 +156,30 @@ Launch:
 - **`list-contacts`**
 
   Displays contacts from all accounts.
+  Returns up to 20 contacts by default. Use `--page-size <count>` to control page size and `--limit <count>` to override the total number of returned contacts.
 
 - **`show-all-messages`**
 
   Shows all messages from all accounts.
+  Returns up to 20 messages by default. Use `--page-size <count>` to control page size and `--limit <count>` to override the total number of returned messages.
 
 - **`show-folder-messages`**
 
   Shows messages from a specific account folder.
+  Returns up to 20 messages by default. Use `--page-size <count>` to control page size and `--limit <count>` to override the total number of returned messages.
 
 - **`show-contact-messages`**
 
   Shows messages for a specific contact.
+  Returns up to 20 messages by default. Use `--page-size <count>` to control page size and `--limit <count>` to override the total number of returned messages.
 
 - **`show-message`**
 
   Shows details of a specific message.
+
+- **`delete-message`**
+
+  Deletes a specific message.
 
 - **`sync-folder`**
 
@@ -174,6 +188,7 @@ Launch:
 - **`send`**
 
   Sends a message.
+  In `--non-interactive=true` mode, the message body is read from `stdin` until end-of-stream.
 
 - **`restore`**
 
@@ -204,6 +219,9 @@ List your connected mailboxes with `list-accounts`. Show all messages with `show
 Next time you log in to Eppie, run `open` command and enter your password.
 
 Send a message with `send -s <sender address> -r <receiver address> -t <subject>`.
+In `--non-interactive=true` mode, pass the vault password as the first `stdin` line when using `--unlock-password-stdin=true`, then write the message body and close `stdin`.
+
+For destructive automation such as `reset`, use `--assume-yes=true` together with `--non-interactive=true`.
 
 ## Planned features
 

--- a/docs/eppie-cli-agent-skill.md
+++ b/docs/eppie-cli-agent-skill.md
@@ -1,0 +1,627 @@
+# Eppie CLI agent skill
+
+Use this skill when an autonomous or semi-autonomous agent must operate `eppie-console` directly.
+
+`eppie-console` is a console mail client that can work with:
+- Gmail,
+- Outlook,
+- Proton Mail,
+- regular IMAP/SMTP email services,
+- decentralized peer-to-peer Eppie mail.
+
+## Purpose
+
+Use `eppie-console` in a predictable, automation-friendly way to:
+- inspect accounts,
+- inspect folders,
+- read messages,
+- send messages,
+- sync folders,
+- initialize, unlock, and reset the local vault when needed by the task.
+
+This skill focuses on deterministic command execution, structured output handling, and explicit standard-input contracts.
+
+For end-to-end validation, coverage, and reproducible test scenarios, use `eppie-cli-agent-test-plan.md`.
+
+## How to use this file
+
+Treat sections marked `Normative` as the required contract for agent execution.
+Treat sections marked `Reference` as supporting material, examples, or quick navigation aids.
+
+Normative sections in this file:
+- `Normative defaults for agents`
+- `Normative rules`
+- `Normative command patterns for agents`
+- `Normative stdin contracts`
+- `Normative execution policy for autonomous agents`
+- `Normative error handling`
+
+Reference sections in this file:
+- `Reference: preferred installation`
+- `Reference: required inputs`
+- `Reference: launch modes`
+- `Reference: decision guide`
+- `Reference: end-to-end agent scenarios`
+- `Reference: command-specific notes and examples`
+- `Reference: recommended agent workflow`
+- `Reference: known limitations`
+- `Reference: contributing`
+
+## Normative defaults for agents
+
+When the task requires executing `eppie-console`, use these defaults unless the task explicitly requires otherwise:
+
+1. use `--non-interactive=true`
+2. use `--output=json` for agent automation unless text output is explicitly required
+3. use `--unlock-password-stdin=true` for stateful commands that need an existing vault
+4. use `--assume-yes=true` for destructive automation
+5. provide `stdin` exactly in the required order
+6. use one consistent working directory per vault
+
+Canonical command patterns and exact `stdin` contracts are defined later in this file. Use those sections as the single source of truth for agent execution.
+
+## Use this skill when
+
+- the task requires executing `eppie-console`
+- the agent must inspect accounts, folders, messages, or contacts
+- the agent must send a message
+- the agent must synchronize a folder
+- the agent must initialize or reset the local vault
+- the agent must work with machine-readable CLI output
+
+## Do not use this skill when
+
+- the task does not require calling `eppie-console`
+- the task is only to explain behavior conceptually without running commands
+- the task is primarily about test coverage or validation workflows; use `eppie-cli-agent-test-plan.md`
+- an interactive REPL session is not explicitly required but would be the only execution path
+- the required executable or working directory is unavailable
+
+## Reference: preferred installation
+
+Prefer the executable published in GitHub Releases.
+You can also build from source.
+
+Latest release page:
+- https://github.com/Eppie-io/Eppie-CLI/releases/latest
+
+Direct download links:
+
+### Linux
+- https://github.com/Eppie-io/Eppie-CLI/releases/latest/download/Eppie.CLI-linux-x64.tar.gz
+- https://github.com/Eppie-io/Eppie-CLI/releases/latest/download/Eppie.CLI-linux-arm64.tar.gz
+
+### macOS
+- https://github.com/Eppie-io/Eppie-CLI/releases/latest/download/Eppie.CLI-osx-x64.tar.gz
+- https://github.com/Eppie-io/Eppie-CLI/releases/latest/download/Eppie.CLI-osx-arm64.tar.gz
+
+### Windows
+- https://github.com/Eppie-io/Eppie-CLI/releases/latest/download/Eppie.CLI-win-x64.zip
+- https://github.com/Eppie-io/Eppie-CLI/releases/latest/download/Eppie.CLI-win-arm64.zip
+
+After extracting the archive, use the `eppie-console` executable directly.
+
+## Reference: required inputs
+
+### Common inputs
+- path to `eppie-console`
+- working directory
+- whether the task requires stateful access to an existing vault
+- whether structured JSON output is required
+
+### Vault access inputs
+- vault password
+- whether the vault must be initialized first
+
+### Reading inputs
+- account identifier for `-a`; for agent workflows, use the account address string returned by `list-accounts` in `data[].address`
+- folder name when folder-specific access is needed
+- message `id`
+- message `pk`
+- page size and total limit for paged commands
+
+### Sending inputs
+- sender address
+- receiver address
+- subject
+- message body
+
+### Account creation inputs
+- account type
+- vault password
+- structured JSON payload when required
+- provider-specific secrets only through standard input when supported
+
+## Reference: launch modes
+
+### Interactive mode
+Use only when a REPL session is explicitly needed.
+
+Example:
+- `eppie-console`
+
+Typical sequence:
+- `open`
+- vault password
+- `list-accounts`
+- `exit`
+
+`open` is useful in interactive mode to open the local vault inside the current process.
+
+### Non-interactive mode
+Prefer this mode for agents.
+
+Use:
+- `eppie-console --non-interactive=true <command> [command options]`
+
+To avoid passing the same startup flags on every call, you can put them in `appsettings.json` next to `eppie-console`, for example:
+- `{ "non-interactive": true, "output": "json", "unlock-password-stdin": true }`
+
+For structured machine-readable output, also use:
+- `--output=json`
+
+JSON responses use a normalized envelope:
+- `type`: `result`, `status`, `warning`, or `error`
+- `code`: stable machine-readable outcome code
+- `data`: payload for `result` and `status` responses
+- `meta`: optional metadata for `result` responses; usually `null`, but paged read commands can return objects such as `{"header":"All messages:","returned":5,"hasMore":true}`
+- `message`: human-readable warning/error text
+
+In `--non-interactive=true --output=json` mode, structured responses are emitted on `stdout` without a preceding stack trace on `stderr` for handled command failures such as `unhandledException`.
+
+In non-interactive mode, do not use `open` as part of the agent workflow. It does not establish reusable state for later process launches. For stateful non-interactive commands, use `--unlock-password-stdin=true` instead.
+
+For all agent examples in this file, `<account>` means the account address returned by `list-accounts` in `data[].address`. Prefer that address string for `-a` instead of the numeric `id`, unless a command explicitly documents another identifier format.
+
+Common success-output examples:
+- `--non-interactive=true --output=json list-accounts` (with accounts):
+  - `{"type":"result","code":"accounts","data":[{"id":1,"address":"<address>","accountType":"Dec"}],"meta":null}`
+- `--non-interactive=true --assume-yes=true --output=json reset`:
+  - `{"type":"status","code":"reset","data":null}`
+- `--non-interactive=true --unlock-password-stdin=true --output=json send ...`:
+  - `{"type":"status","code":"messageSent","data":{"subject":"<subject>","to":"<receiver>","from":"<sender>"}}`
+- `--non-interactive=true --unlock-password-stdin=true --output=json sync-folder ...`:
+  - `{"type":"status","code":"folderSynced","data":{"account":"<account>","folder":"Inbox"}}`
+- `--non-interactive=true --unlock-password-stdin=true --output=json show-all-messages ...`:
+  - `{"type":"result","code":"messages","data":[{"id":1,"pk":1,"to":["<receiver>"],"from":["<sender>"],"folder":"Inbox","subject":"<subject>"}],"meta":{"header":"All messages:","returned":1,"hasMore":false}}`
+
+Additional command-specific JSON result shapes are documented later in `Reference: command-specific notes and examples`.
+
+Common text success-output examples:
+- `open`:
+  - `The application was opened successfully.`
+- `reset`:
+  - `The application has just been reset.`
+- `add-account -t dec`:
+  - `Account <generated-address> added (Dec).`
+- `send`:
+  - `Message sent from <sender> to <receiver>. Subject: <subject>`
+- `sync-folder -f Inbox`:
+  - `Folder 'Inbox' for account <account> synchronized.`
+
+## Normative rules
+
+- Treat `Normative command patterns for agents` and `Normative stdin contracts` as normative for agent workflows.
+- Put global launch options before the startup command.
+- Do not assume `open` creates a reusable session for future process launches.
+- Synchronize the relevant folder before reading when the task requires newly arrived messages.
+- Do not guess provider-specific folder names; call `list-folders` first.
+- Use `-l` / `--limit` when predictable payload size matters.
+- Do not pass account secrets in command-line arguments when structured standard input is supported.
+
+`eppie-console open` only opens the vault inside the current process.
+It does **not** create a reusable session for future process launches.
+
+## Normative command patterns for agents
+
+Use this section as the single source of truth for agent command lines. Unless text output is explicitly required, all agent examples below use `--output=json`.
+
+| Task | Canonical command |
+| --- | --- |
+| Initialize a vault | `--non-interactive=true --output=json init` |
+| List accounts | `--non-interactive=true --unlock-password-stdin=true --output=json list-accounts` |
+| List folders | `--non-interactive=true --unlock-password-stdin=true --output=json list-folders -a <account>` |
+| Show all messages | `--non-interactive=true --unlock-password-stdin=true --output=json show-all-messages -s 10 -l 10` |
+| Show one message | `--non-interactive=true --unlock-password-stdin=true --output=json show-message -a <account> -f <folder> -i <id> -k <pk>` |
+| Delete one message | `--non-interactive=true --unlock-password-stdin=true --output=json delete-message -a <account> -f <folder> -i <id> -k <pk>` |
+| List contacts | `--non-interactive=true --unlock-password-stdin=true --output=json list-contacts -s 10 -l 10` |
+| Show contact messages | `--non-interactive=true --unlock-password-stdin=true --output=json show-contact-messages -c <contact> -s 10 -l 10` |
+| Show folder messages | `--non-interactive=true --unlock-password-stdin=true --output=json show-folder-messages -a <account> -f <folder> -s 10 -l 10` |
+| Sync a folder | `--non-interactive=true --unlock-password-stdin=true --output=json sync-folder -a <account> -f <folder>` |
+| Send a message | `--non-interactive=true --unlock-password-stdin=true --output=json send -s <sender> -r <receiver> -t "<subject>"` |
+| Reset local data | `--non-interactive=true --assume-yes=true --output=json reset` |
+| Add a DEC account | `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t dec` |
+| Add a regular IMAP/SMTP account | `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t email --input-json-stdin` |
+| Add a Proton Mail account | `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t proton --input-json-stdin` |
+
+## Normative stdin contracts
+
+Provide `stdin` exactly in the documented order. Unless a command explicitly reads until end-of-stream, stop after the documented input has been written.
+
+| Command | Exact `stdin` contract | EOF required |
+| --- | --- | --- |
+| `--non-interactive=true --output=json init` | line 1: new vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json list-accounts` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json list-folders -a <account>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json show-all-messages -s <page-size> -l <limit>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json show-message -a <account> -f <folder> -i <id> -k <pk>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json delete-message -a <account> -f <folder> -i <id> -k <pk>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json list-contacts -s <page-size> -l <limit>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json show-contact-messages -c <contact> -s <page-size> -l <limit>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json show-folder-messages -a <account> -f <folder> -s <page-size> -l <limit>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json sync-folder -a <account> -f <folder>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json send -s <sender> -r <receiver> -t "<subject>"` | line 1: vault password; line 2 and later: message body; then close `stdin` | yes |
+| `--non-interactive=true --assume-yes=true --output=json reset` | no `stdin` | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t dec` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t email --input-json-stdin` | line 1: vault password; remaining bytes: one JSON object | yes |
+| `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t proton --input-json-stdin` | line 1: vault password; remaining bytes: one JSON object | yes |
+
+### Command summary
+
+| Command group | Needs existing vault | Use `--unlock-password-stdin=true` | Prefer `--output=json` | Notes |
+| --- | --- | --- | --- | --- |
+| `init` | no | no | yes for agent workflows | writes a new local vault password from `stdin` |
+| `reset` | no | no | yes | destructive; also use `--assume-yes=true` |
+| `list-accounts`, `list-folders` | yes | yes | yes | inspect vault content |
+| `show-all-messages`, `show-message`, `show-folder-messages`, `show-contact-messages` | yes | yes | yes | use `-l` when payload size matters |
+| `sync-folder` | yes | yes | yes | call before reading when fresh messages are required |
+| `send` | yes | yes | yes | password first in `stdin`, then body until EOF |
+| `add-account -t dec` | yes | yes | yes | simple vault-backed account creation |
+| `add-account -t email`, `add-account -t proton` | yes | yes | yes | use `--input-json-stdin`; do not pass secrets in arguments |
+
+### Avoid these mistakes
+
+- Do not use `open` in a non-interactive workflow.
+- Do not guess provider-specific folder names; call `list-folders` first.
+- Do not rely only on process exit code when JSON output is available.
+- Do not omit `-l` when an agent needs a predictable maximum payload size.
+- Do not pass secrets in command-line arguments when structured standard input is supported.
+
+## Normative execution policy for autonomous agents
+
+### Output handling
+- Follow the `Normative defaults for agents` defaults unless the task explicitly requires otherwise.
+- Parse `type`, `code`, `data`, `meta`, and `message` from the normalized envelope.
+- Do not rely only on process exit code when structured output is available.
+- Treat `warning` and `error` responses as non-success outcomes even when the process exits cleanly.
+
+### Standard input handling
+- Follow `Normative stdin contracts` exactly.
+- For `send`, close `stdin` after the last body line.
+- For commands using `--input-json-stdin`, pass the password first when required, then the JSON payload.
+- Do not prepend labels, prompts, or extra blank lines to the documented `stdin` contract.
+
+### Working directory handling
+- Use one consistent working directory for related commands that operate on the same local vault.
+- Use an isolated working directory when the run is disposable or destructive.
+
+### Account identifier handling
+- For agent workflows, pass the account address from `list-accounts` `data[].address` to `-a`.
+- Do not assume the numeric `id` is accepted interchangeably by all commands.
+- Re-read the current address from `list-accounts` when a workflow depends on a newly created account.
+
+### Pagination handling
+- Use both `-s` / `--page-size` and `-l` / `--limit` in agent workflows when payload size must be predictable.
+- Treat `-s` as page size only. Treat `-l` as the total maximum number of records returned by the command.
+- If `-l` is omitted, paged read commands return up to 20 records by default.
+- Use `meta.returned` to confirm how many records were actually returned.
+- Use `meta.hasMore` to decide whether another read with a higher `-l` or a narrower filter is needed.
+- Do not assume provider folders or message volume are small enough to omit `-l`.
+
+## Reference: decision guide
+
+Use `Normative command patterns for agents` for the exact command line. This guide is only for choosing the next command.
+
+- inspect available accounts → `list-accounts`
+- inspect available folders for an account → `list-folders`
+- inspect recent messages across folders → sync the relevant folders when new messages are required, then use `show-all-messages`
+- inspect messages in a specific folder → `list-folders`, then `sync-folder`, then `show-folder-messages` when new messages are required
+- inspect one message → `show-message`
+- delete one message → `delete-message`
+- inspect contacts → `list-contacts`
+- inspect messages for one contact → `show-contact-messages`
+- send a message → `send`
+- sync one folder → `list-folders`, then `sync-folder`
+- initialize a vault → `init`
+- reset local data → `reset`
+
+## Reference: end-to-end agent scenarios
+
+This section is informative. Use `Normative command patterns for agents` for the exact command line and `Normative stdin contracts` for the exact `stdin` shape.
+
+### Initialize a new vault, add an account, then verify it
+
+Use this flow when the working directory does not yet contain the required local vault.
+
+1. initialize the vault with `init`
+2. add the required account with `add-account`
+3. verify the created account with `list-accounts`
+4. use the returned `data[].address` as `<account>` in later commands
+
+Typical sequences:
+- DEC account: `init` → `add-account -t dec` → `list-accounts`
+- regular IMAP/SMTP account: `init` → `add-account -t email` → `list-accounts`
+- Proton Mail account: `init` → `add-account -t proton` → `list-accounts`
+
+Agent notes:
+- keep one consistent working directory across the whole sequence so all commands operate on the same local vault
+- for `add-account -t email` and `add-account -t proton`, provide the structured payload through standard input after the vault password as documented in `Normative stdin contracts`
+- after account creation, re-read the current address from `list-accounts` instead of assuming another identifier format
+
+### Read the latest message from a specific folder
+
+Use this flow when the task requires a concrete folder such as inbox or sent mail and the messages may have changed since the last sync.
+
+1. inspect accounts with `list-accounts`
+2. inspect folders for the chosen account with `list-folders`
+3. choose the correct folder name from `data[].fullName` or `data[].roles`
+4. synchronize that folder with `sync-folder`
+5. read a bounded message list with `show-folder-messages`
+6. open one returned message with `show-message` using its `id` and `pk`
+
+Typical sequence:
+- `list-accounts` → `list-folders` → `sync-folder` → `show-folder-messages` → `show-message`
+
+Agent notes:
+- do not guess the folder name; use the `fullName` returned by `list-folders`
+- use `-s` and `-l` on `show-folder-messages` when predictable payload size matters
+- when `meta.hasMore` is `true`, treat the result as partial and increase `-l` only if the task requires a larger set
+
+### Send a message from an existing account
+
+Use this flow when the local vault already contains the sender account and the task is to deliver one message deterministically.
+
+1. inspect accounts with `list-accounts`
+2. choose the sender address from `data[].address`
+3. call `send` with the sender, receiver, and subject
+4. pass the vault password on the first `stdin` line
+5. pass the message body starting from line 2, then close `stdin`
+
+Typical sequence:
+- `list-accounts` → `send`
+
+Agent notes:
+- if the sender is unknown or the workflow depends on a newly created account, refresh the account list before sending
+- in `--non-interactive=true` mode, `send` reads the body until end-of-stream, so the agent should close `stdin` after the last body line
+- prefer `--output=json` and verify the `messageSent` status response instead of relying only on the process exit code
+
+## Reference: command-specific notes and examples
+
+The canonical command lines are defined in `Normative command patterns for agents`, and the exact inputs are defined in `Normative stdin contracts`. This section keeps only command-specific notes, result shapes, and examples that are easy to reference during agent execution.
+
+### Init local vault
+Notes:
+- writes a new local vault password from `stdin`
+
+### Show all messages
+Notes:
+- `-s` / `--page-size` controls only the page size
+- `-l` / `--limit` caps the total number of returned records and should be used by agents to keep payload size predictable
+- if `-l` is omitted, paged read commands return up to 20 records by default
+- message items use the same address shape as `show-message`: `to` and `from` are arrays
+- paged result metadata can include `returned` and `hasMore`
+- agents should check `meta.hasMore` before assuming the returned list is complete
+
+### List folders
+Expected result shape:
+- `{"type":"result","code":"folders","data":[{"fullName":"Inbox","unreadCount":0,"totalCount":0,"roles":["inbox"]}],"meta":{"account":"<account>"}}`
+
+Notes:
+- `<account>` should be the account address from `list-accounts` `data[].address`
+- use this command before `show-folder-messages` or `sync-folder` instead of guessing provider-specific folder names
+- Proton may expose names such as `All Sent`; rely on the returned `fullName`
+- use `roles` when you need a machine-readable way to find folders such as inbox or sent mail
+
+### Delete one message
+Notes:
+- when called for a message outside `Trash`, the command moves the message to `Trash`
+- when called for a message already in `Trash`, the command deletes it permanently
+
+### Show contact messages
+Notes:
+- paged result metadata can include `returned` and `hasMore`
+
+### Show folder messages
+Notes:
+- paged result metadata can include `returned` and `hasMore`
+
+### Sync folder
+Expected result shape:
+- `{"type":"status","code":"folderSynced","data":{"account":"<account>","folder":"Inbox"}}`
+
+### Send message
+Examples:
+- `vault password`
+- `Hello from automation`
+- `Second body line`
+- close `stdin`
+
+Notes:
+- in `--non-interactive=true` mode, `send` reads the message body until end-of-stream
+- JSON success shape: `{"type":"status","code":"messageSent","data":{"subject":"<subject>","to":"<receiver>","from":"<sender>"}}`
+
+PowerShell example with the command line and exact `stdin` in one block:
+
+```powershell
+@"
+vault password
+Hello from automation
+Second body line
+"@ | .\eppie-console --non-interactive=true --unlock-password-stdin=true --output=json send -s sender@example.com -r receiver@example.com -t "Hello from automation"
+```
+
+Linux / bash example with the command line and exact `stdin` in one block:
+
+```bash
+cat <<'EOF_INPUT' | ./eppie-console --non-interactive=true --unlock-password-stdin=true --output=json send -s sender@example.com -r receiver@example.com -t "Hello from automation"
+vault password
+Hello from automation
+Second body line
+EOF_INPUT
+```
+
+Notes:
+- on Linux and macOS, use `./eppie-console` after extracting the archive and making sure the file is executable.
+
+### Open local vault
+Use `open` only in interactive mode when the agent is already inside a REPL session and must open the local vault in that same process.
+
+Notes:
+- do not use `open` as part of the non-interactive agent workflow
+
+### Reset local data
+Notes:
+- `reset` is a destructive command and should be called with `--assume-yes=true` in automation or other non-interactive scripts.
+
+### Add DEC account
+Expected result shape:
+- `{"type":"result","code":"accountAdded","data":{"address":"<generated-address>","accountType":"Dec"},"meta":null}`
+
+### Add regular IMAP/SMTP account
+Examples:
+
+JSON object:
+
+```json
+{
+  "email": "user@example.com",
+  "accountPassword": "account password",
+  "imapServer": "imap.example.com",
+  "imapPort": 993,
+  "smtpServer": "smtp.example.com",
+  "smtpPort": 465
+}
+```
+
+`stdin` shape:
+- first line: `vault password`
+- remaining bytes:
+
+```json
+{"email":"user@example.com","accountPassword":"account password","imapServer":"imap.example.com","imapPort":993,"smtpServer":"smtp.example.com","smtpPort":465}
+```
+
+Notes:
+- use this mode for regular IMAP/SMTP providers when browser-based OAuth is not needed
+- do not pass account secrets in command-line arguments
+- required structured properties are `email`, `accountPassword`, `imapServer`, `imapPort`, `smtpServer`, and `smtpPort`
+- invalid structured input returns one of these machine-readable errors:
+  - `structuredStandardInputInvalidJson`
+  - `structuredStandardInputMissingProperty`
+
+### Add Proton Mail account
+Examples:
+
+JSON object:
+
+```json
+{
+  "email": "user@proton.me",
+  "accountPassword": "account password",
+  "mailboxPassword": "mailbox password",
+  "twoFactorCode": "123456"
+}
+```
+
+`stdin` shape:
+- first line: `vault password`
+- remaining bytes:
+
+```json
+{"email":"user@proton.me","accountPassword":"account password","mailboxPassword":"mailbox password"}
+```
+
+Notes:
+- do not pass Proton secrets in command-line arguments
+- `email` and `accountPassword` are required in structured input
+- `mailboxPassword` is required only if the Proton flow asks for it
+- `twoFactorCode` is required only if the Proton flow asks for it
+- if the mailbox password is the same as the account password, repeat the same value in `mailboxPassword`
+- invalid structured input returns one of these machine-readable errors:
+  - `structuredStandardInputInvalidJson`
+  - `structuredStandardInputMissingProperty`
+
+## Reference: recommended agent workflow
+
+1. Start from the defaults in `Normative defaults for agents`.
+2. Choose the exact command line from `Normative command patterns for agents`.
+3. Provide `stdin` in the exact shape defined in `Normative stdin contracts`.
+4. Use the account address from `list-accounts` `data[].address` for `-a`.
+5. Use an isolated working directory when the run is disposable or destructive.
+6. For message reading:
+   - start with `list-folders` if the next step requires a specific folder name,
+   - synchronize the relevant folder before reading when you need newly arrived messages,
+   - then use `show-all-messages` when you need recent messages across all folders,
+   - then call `show-message` or `delete-message` with the returned `id` and `pk`.
+7. In `--non-interactive=true` mode text output stops after the first page instead of prompting.
+8. For common task chains, use `Reference: end-to-end agent scenarios` as a quick reference.
+
+## Reference: known limitations
+
+### Some commands still require explicit non-interactive inputs
+`--non-interactive=true` suppresses interactive prompts, but it does not invent missing data.
+
+Commands that normally ask follow-up questions still need explicit arguments or `stdin` data.
+The main examples are already covered above:
+- `send` reads the message body until end-of-stream in `--non-interactive=true` mode
+- `add-account -t email` and `add-account -t proton` should use `--input-json-stdin`
+- destructive commands such as `reset` still need `--assume-yes=true`
+- paged read commands still default to 20 records when `-l` is omitted
+
+## Normative error handling
+
+For agent automation, prefer deterministic handling over implicit retries.
+
+### Interpret the normalized envelope
+
+When `--output=json` is enabled, handle responses by `type` first:
+
+| `type` | Meaning | Agent action |
+| --- | --- | --- |
+| `result` | command returned data | parse `data` and `meta` |
+| `status` | command completed successfully without a list-style result | read `data` when present |
+| `warning` | handled problem or non-success condition | inspect `code`; do not assume success; stop unless the workflow explicitly defines a recovery step |
+| `error` | handled failure | inspect `code`, `message`, and `data`; stop unless the input can be corrected deterministically |
+
+### Common machine-readable codes
+
+| `code` | Meaning | Typical agent response |
+| --- | --- | --- |
+| `invalidPassword` | vault password was rejected | stop; do not retry automatically with the same password |
+| `structuredStandardInputInvalidJson` | structured payload is not valid JSON | fix serialization and retry once with corrected JSON |
+| `structuredStandardInputMissingProperty` | required JSON property is missing or empty | provide the missing property and retry once |
+| `unhandledException` | command failed and returned exception details | inspect `data.exceptionType` and command context; do not retry blindly |
+
+### Agent response rules
+
+- Parse `type` first, then `code`.
+- Do not treat `warning` as success.
+- Do not retry `invalidPassword` automatically.
+- Retry only when the failure is deterministic and local to the request, such as malformed JSON or a missing structured property.
+- When retrying after `structuredStandardInputInvalidJson` or `structuredStandardInputMissingProperty`, change only the invalid input and keep the command line unchanged.
+- For `unhandledException`, record the command, the parsed `code`, and `data.exceptionType` when present.
+- When a paged read returns `meta.hasMore: true`, treat that as an incomplete result set rather than an error.
+
+### Error-output examples
+
+Invalid password example:
+- `{"type":"warning","code":"invalidPassword","message":"Warning: Invalid password.","data":null}`
+
+Unknown sender account example for `send`:
+- `{"type":"error","code":"unhandledException","message":"An error has occurred: ...","data":{"exceptionType":"Tuvi.Core.Entities.AccountIsNotExistInDatabaseException"}}`
+
+Invalid Proton structured input example:
+- `{"type":"error","code":"structuredStandardInputInvalidJson","message":"Error: The remaining standard input for the 'add-account' command is not valid JSON.","data":{"commandName":"add-account"}}`
+
+Missing Proton structured property example:
+- `{"type":"error","code":"structuredStandardInputMissingProperty","message":"Error: The structured standard input for the 'add-account' command must contain a non-empty 'email' property.","data":{"commandName":"add-account","propertyName":"email"}}`
+
+## Reference: contributing
+
+Contributions are welcome.
+
+Please open issues for bugs, UX problems, and feature ideas.
+Pull requests on GitHub are also welcome.
+
+Repository:
+- https://github.com/Eppie-io/Eppie-CLI

--- a/docs/eppie-cli-agent-skill.md
+++ b/docs/eppie-cli-agent-skill.md
@@ -206,7 +206,7 @@ Common text success-output examples:
 ## Normative rules
 
 - Treat `Normative command patterns for agents` and `Normative stdin contracts` as normative for agent workflows.
-- Put global launch options before the startup command.
+- Put global launch options before `--` and put the startup command after `--`.
 - Do not assume `open` creates a reusable session for future process launches.
 - Synchronize the relevant folder before reading when the task requires newly arrived messages.
 - Do not guess provider-specific folder names; call `list-folders` first.
@@ -222,21 +222,21 @@ Use this section as the single source of truth for agent command lines. Unless t
 
 | Task | Canonical command |
 | --- | --- |
-| Initialize a vault | `--non-interactive=true --output=json init` |
-| List accounts | `--non-interactive=true --unlock-password-stdin=true --output=json list-accounts` |
-| List folders | `--non-interactive=true --unlock-password-stdin=true --output=json list-folders -a <account>` |
-| Show all messages | `--non-interactive=true --unlock-password-stdin=true --output=json show-all-messages -s 10 -l 10` |
-| Show one message | `--non-interactive=true --unlock-password-stdin=true --output=json show-message -a <account> -f <folder> -i <id> -k <pk>` |
-| Delete one message | `--non-interactive=true --unlock-password-stdin=true --output=json delete-message -a <account> -f <folder> -i <id> -k <pk>` |
-| List contacts | `--non-interactive=true --unlock-password-stdin=true --output=json list-contacts -s 10 -l 10` |
-| Show contact messages | `--non-interactive=true --unlock-password-stdin=true --output=json show-contact-messages -c <contact> -s 10 -l 10` |
-| Show folder messages | `--non-interactive=true --unlock-password-stdin=true --output=json show-folder-messages -a <account> -f <folder> -s 10 -l 10` |
-| Sync a folder | `--non-interactive=true --unlock-password-stdin=true --output=json sync-folder -a <account> -f <folder>` |
-| Send a message | `--non-interactive=true --unlock-password-stdin=true --output=json send -s <sender> -r <receiver> -t "<subject>"` |
-| Reset local data | `--non-interactive=true --assume-yes=true --output=json reset` |
-| Add a DEC account | `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t dec` |
-| Add a regular IMAP/SMTP account | `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t email --input-json-stdin` |
-| Add a Proton Mail account | `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t proton --input-json-stdin` |
+| Initialize a vault | `--non-interactive=true --output=json -- init` |
+| List accounts | `--non-interactive=true --unlock-password-stdin=true --output=json -- list-accounts` |
+| List folders | `--non-interactive=true --unlock-password-stdin=true --output=json -- list-folders -a <account>` |
+| Show all messages | `--non-interactive=true --unlock-password-stdin=true --output=json -- show-all-messages -s 10 -l 10` |
+| Show one message | `--non-interactive=true --unlock-password-stdin=true --output=json -- show-message -a <account> -f <folder> -i <id> -k <pk>` |
+| Delete one message | `--non-interactive=true --unlock-password-stdin=true --output=json -- delete-message -a <account> -f <folder> -i <id> -k <pk>` |
+| List contacts | `--non-interactive=true --unlock-password-stdin=true --output=json -- list-contacts -s 10 -l 10` |
+| Show contact messages | `--non-interactive=true --unlock-password-stdin=true --output=json -- show-contact-messages -c <contact> -s 10 -l 10` |
+| Show folder messages | `--non-interactive=true --unlock-password-stdin=true --output=json -- show-folder-messages -a <account> -f <folder> -s 10 -l 10` |
+| Sync a folder | `--non-interactive=true --unlock-password-stdin=true --output=json -- sync-folder -a <account> -f <folder>` |
+| Send a message | `--non-interactive=true --unlock-password-stdin=true --output=json -- send -s <sender> -r <receiver> -t "<subject>"` |
+| Reset local data | `--non-interactive=true --assume-yes=true --output=json -- reset` |
+| Add a DEC account | `--non-interactive=true --unlock-password-stdin=true --output=json -- add-account -t dec` |
+| Add a regular IMAP/SMTP account | `--non-interactive=true --unlock-password-stdin=true --output=json -- add-account -t email --input-json-stdin` |
+| Add a Proton Mail account | `--non-interactive=true --unlock-password-stdin=true --output=json -- add-account -t proton --input-json-stdin` |
 
 ## Normative stdin contracts
 
@@ -244,21 +244,21 @@ Provide `stdin` exactly in the documented order. Unless a command explicitly rea
 
 | Command | Exact `stdin` contract | EOF required |
 | --- | --- | --- |
-| `--non-interactive=true --output=json init` | line 1: new vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json list-accounts` | line 1: vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json list-folders -a <account>` | line 1: vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json show-all-messages -s <page-size> -l <limit>` | line 1: vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json show-message -a <account> -f <folder> -i <id> -k <pk>` | line 1: vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json delete-message -a <account> -f <folder> -i <id> -k <pk>` | line 1: vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json list-contacts -s <page-size> -l <limit>` | line 1: vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json show-contact-messages -c <contact> -s <page-size> -l <limit>` | line 1: vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json show-folder-messages -a <account> -f <folder> -s <page-size> -l <limit>` | line 1: vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json sync-folder -a <account> -f <folder>` | line 1: vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json send -s <sender> -r <receiver> -t "<subject>"` | line 1: vault password; line 2 and later: message body; then close `stdin` | yes |
-| `--non-interactive=true --assume-yes=true --output=json reset` | no `stdin` | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t dec` | line 1: vault password | no |
-| `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t email --input-json-stdin` | line 1: vault password; remaining bytes: one JSON object | yes |
-| `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t proton --input-json-stdin` | line 1: vault password; remaining bytes: one JSON object | yes |
+| `--non-interactive=true --output=json -- init` | line 1: new vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- list-accounts` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- list-folders -a <account>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- show-all-messages -s <page-size> -l <limit>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- show-message -a <account> -f <folder> -i <id> -k <pk>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- delete-message -a <account> -f <folder> -i <id> -k <pk>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- list-contacts -s <page-size> -l <limit>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- show-contact-messages -c <contact> -s <page-size> -l <limit>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- show-folder-messages -a <account> -f <folder> -s <page-size> -l <limit>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- sync-folder -a <account> -f <folder>` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- send -s <sender> -r <receiver> -t "<subject>"` | line 1: vault password; line 2 and later: message body; then close `stdin` | yes |
+| `--non-interactive=true --assume-yes=true --output=json -- reset` | no `stdin` | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- add-account -t dec` | line 1: vault password | no |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- add-account -t email --input-json-stdin` | line 1: vault password; remaining bytes: one JSON object | yes |
+| `--non-interactive=true --unlock-password-stdin=true --output=json -- add-account -t proton --input-json-stdin` | line 1: vault password; remaining bytes: one JSON object | yes |
 
 ### Command summary
 
@@ -451,13 +451,13 @@ PowerShell example with the command line and exact `stdin` in one block:
 vault password
 Hello from automation
 Second body line
-"@ | .\eppie-console --non-interactive=true --unlock-password-stdin=true --output=json send -s sender@example.com -r receiver@example.com -t "Hello from automation"
+"@ | .\eppie-console --non-interactive=true --unlock-password-stdin=true --output=json -- send -s sender@example.com -r receiver@example.com -t "Hello from automation"
 ```
 
 Linux / bash example with the command line and exact `stdin` in one block:
 
 ```bash
-cat <<'EOF_INPUT' | ./eppie-console --non-interactive=true --unlock-password-stdin=true --output=json send -s sender@example.com -r receiver@example.com -t "Hello from automation"
+cat <<'EOF_INPUT' | ./eppie-console --non-interactive=true --unlock-password-stdin=true --output=json -- send -s sender@example.com -r receiver@example.com -t "Hello from automation"
 vault password
 Hello from automation
 Second body line

--- a/docs/eppie-cli-agent-skill.md
+++ b/docs/eppie-cli-agent-skill.md
@@ -157,6 +157,10 @@ Use:
 To avoid passing the same startup flags on every call, you can put them in `appsettings.json` next to `eppie-console`, for example:
 - `{ "non-interactive": true, "output": "json", "unlock-password-stdin": true }`
 
+`eppie-console` also reads configuration from environment variables.
+
+When the default .NET host configuration pipeline is used, environment variables override `appsettings.json`. Command-line arguments override both.
+
 For structured machine-readable output, also use:
 - `--output=json`
 

--- a/docs/eppie-cli-agent-test-plan.md
+++ b/docs/eppie-cli-agent-test-plan.md
@@ -20,7 +20,7 @@ Cover:
 
 1. Prefer `--non-interactive=true` for automation.
 2. Prefer `--output=json` when validating machine-readable behavior.
-3. Put global launch options before the startup command.
+3. Put global launch options before `--` and put the startup command after `--`.
 4. For stateful non-interactive commands, use `--unlock-password-stdin=true`.
 5. For destructive commands such as `reset`, use `--assume-yes=true` unless intentionally testing the warning path.
 6. Use one isolated working directory per scenario.
@@ -131,7 +131,7 @@ This is the main scenario that should run first.
 
 ### 1. Initialize a fresh vault
 Command:
-- `--non-interactive=true --output=json init`
+- `--non-interactive=true --output=json -- init`
 
 `stdin`:
 1. vault password
@@ -143,7 +143,7 @@ Expected result:
 
 ### 2. Verify locked command warning without `--unlock-password-stdin=true`
 Command:
-- `--non-interactive=true --output=json list-accounts`
+- `--non-interactive=true --output=json -- list-accounts`
 
 `stdin`:
 - none
@@ -154,7 +154,7 @@ Expected result:
 
 ### 3. Verify invalid password handling
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json list-accounts`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- list-accounts`
 
 `stdin`:
 1. wrong password
@@ -165,7 +165,7 @@ Expected result:
 
 ### 4. List accounts in a fresh vault
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json list-accounts`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- list-accounts`
 
 `stdin`:
 1. vault password
@@ -178,7 +178,7 @@ Expected result:
 
 ### 5. Add a DEC account
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t dec`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- add-account -t dec`
 
 `stdin`:
 1. vault password
@@ -194,7 +194,7 @@ Store the returned `data.address` as `<dec-address>`.
 
 ### 6. List accounts after account creation
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json list-accounts`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- list-accounts`
 
 `stdin`:
 1. vault password
@@ -208,7 +208,7 @@ Expected result:
 
 ### 6a. List folders for the account
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json list-folders -a <dec-address>`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- list-folders -a <dec-address>`
 
 `stdin`:
 1. vault password
@@ -224,7 +224,7 @@ If one folder is available, store:
 
 ### 7. Send a message to the DEC account itself
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json send -s <dec-address> -r <dec-address> -t "Hello from automation"`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- send -s <dec-address> -r <dec-address> -t "Hello from automation"`
 
 `stdin` order:
 1. vault password
@@ -244,7 +244,7 @@ Notes:
 
 ### 7a. Synchronize the relevant folder before validating newly arrived messages
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json sync-folder -a <dec-address> -f <folder-name>`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- sync-folder -a <dec-address> -f <folder-name>`
 
 `stdin`:
 1. vault password
@@ -257,7 +257,7 @@ If the current account type or folder does not support a meaningful sync in the 
 
 ### 8. Read recent messages after synchronization
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json show-all-messages -s 5 -l 5`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- show-all-messages -s 5 -l 5`
 
 `stdin`:
 1. vault password
@@ -280,7 +280,7 @@ If at least one message is present, store:
 
 ### 9. Read one message
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json show-message -a <dec-address> -f Inbox -i <message-id> -k <message-pk>`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- show-message -a <dec-address> -f Inbox -i <message-id> -k <message-pk>`
 
 `stdin`:
 1. vault password
@@ -297,7 +297,7 @@ Expected result:
 
 ### 10. Read one folder
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json show-folder-messages -a <dec-address> -f <folder-name> -s 5 -l 5`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- show-folder-messages -a <dec-address> -f <folder-name> -s 5 -l 5`
 
 `stdin`:
 1. vault password
@@ -310,7 +310,7 @@ Expected result:
 
 ### 10a. Delete one message
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json delete-message -a <dec-address> -f <folder-name> -i <message-id> -k <message-pk>`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- delete-message -a <dec-address> -f <folder-name> -i <message-id> -k <message-pk>`
 
 `stdin`:
 1. vault password
@@ -336,7 +336,7 @@ Notes:
 
 ### 11. List contacts
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json list-contacts -s 10 -l 10`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- list-contacts -s 10 -l 10`
 
 `stdin`:
 1. vault password
@@ -350,7 +350,7 @@ If one contact is available, store `<contact-address>` from the first item.
 
 ### 12. Read messages for a contact
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json show-contact-messages -c <contact-address> -s 10 -l 10`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- show-contact-messages -c <contact-address> -s 10 -l 10`
 
 `stdin`:
 1. vault password
@@ -365,7 +365,7 @@ Expected result:
 
 ### 13. Reset without `--assume-yes=true` to validate warning behavior
 Command:
-- `--non-interactive=true --output=json reset`
+- `--non-interactive=true --output=json -- reset`
 
 `stdin`:
 - none
@@ -376,7 +376,7 @@ Expected result:
 
 ### 14. Reset with `--assume-yes=true`
 Command:
-- `--non-interactive=true --assume-yes=true --output=json reset`
+- `--non-interactive=true --assume-yes=true --output=json -- reset`
 
 `stdin`:
 - none
@@ -393,9 +393,9 @@ If post-reset validation is needed, use a suitable non-interactive command whose
 In addition to the JSON scenario, validate a small text-mode subset.
 
 Recommended checks:
-- `--non-interactive=true --assume-yes=true reset`
-- `--non-interactive=true --unlock-password-stdin=true add-account -t dec`
-- `--non-interactive=true --unlock-password-stdin=true send -s <sender> -r <receiver> -t "<subject>"`
+- `--non-interactive=true --assume-yes=true -- reset`
+- `--non-interactive=true --unlock-password-stdin=true -- add-account -t dec`
+- `--non-interactive=true --unlock-password-stdin=true -- send -s <sender> -r <receiver> -t "<subject>"`
 
 Expected text samples:
 - `The application has just been reset.`
@@ -406,7 +406,7 @@ Expected text samples:
 
 ### Empty body for `send`
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json send -s <dec-address> -r <dec-address> -t "Empty body"`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- send -s <dec-address> -r <dec-address> -t "Empty body"`
 
 `stdin` order:
 1. vault password
@@ -423,7 +423,7 @@ Note:
 
 ### Unknown sender account
 Command:
-- `--non-interactive=true --unlock-password-stdin=true --output=json send -s missing@eppie -r missing@eppie -t "Missing account"`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- send -s missing@eppie -r missing@eppie -t "Missing account"`
 
 `stdin` order:
 1. vault password
@@ -468,7 +468,7 @@ Validate:
 - message listing.
 
 Recommended automation pattern:
-- `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t proton --input-json-stdin`
+- `--non-interactive=true --unlock-password-stdin=true --output=json -- add-account -t proton --input-json-stdin`
 
 `stdin` shape:
 1. vault password on the first line if `--unlock-password-stdin=true` is used
@@ -545,6 +545,6 @@ A test run is successful when:
 ## Cleanup
 
 After the scenario:
-- run `--non-interactive=true --assume-yes=true reset` if needed,
+- run `--non-interactive=true --assume-yes=true -- reset` if needed,
 - delete the isolated working directory,
 - do not reuse the same vault directory for unrelated scenarios.

--- a/docs/eppie-cli-agent-test-plan.md
+++ b/docs/eppie-cli-agent-test-plan.md
@@ -1,0 +1,550 @@
+# Eppie CLI agent test plan
+
+Use this document when an autonomous or semi-autonomous agent must test `eppie-console` in `--non-interactive=true` mode, with maximum coverage and reproducible results.
+
+This file complements `eppie-cli-agent-skill.md`.
+The skill document explains how an agent should operate the CLI in general.
+This document explains how to validate the non-interactive execution paths.
+
+## Goal
+
+Cover:
+- startup options,
+- command execution in `--non-interactive=true` mode,
+- JSON and text outputs,
+- success and failure cases,
+- local reproducible scenarios,
+- optional provider-specific scenarios that may require manual credentials.
+
+## Core testing rules for AI agents
+
+1. Prefer `--non-interactive=true` for automation.
+2. Prefer `--output=json` when validating machine-readable behavior.
+3. Put global launch options before the startup command.
+4. For stateful non-interactive commands, use `--unlock-password-stdin=true`.
+5. For destructive commands such as `reset`, use `--assume-yes=true` unless intentionally testing the warning path.
+6. Use one isolated working directory per scenario.
+7. Do not assume state is reused across separate process launches.
+8. Do not rely only on process exit code; inspect JSON `type` and `code`.
+9. For `send` in `--non-interactive=true` mode, terminate the body by closing `stdin`.
+10. In JSON automation scenarios, validate that machine-readable output stays on `stdout` and is still parseable even when the command returns `type = error`.
+11. For paged read commands, prefer explicit `-l` when you need reproducible payload size. If `-l` is omitted, the command uses its default total limit.
+12. Synchronize the relevant folder or folders before validating newly arrived messages. Without synchronization, newly arrived messages should not be expected to appear.
+
+To avoid repeating the same startup flags in test commands, you can preset them in `appsettings.json` next to `eppie-console`, for example:
+- `{ "non-interactive": true, "output": "json", "unlock-password-stdin": true }`
+
+## Coverage map
+
+### Startup options
+
+Mandatory coverage:
+- `--non-interactive=true`
+- `--output=json`
+- `--assume-yes=true`
+- `--unlock-password-stdin=true`
+
+Recommended combinations:
+- `--non-interactive=true --output=json`
+- `--non-interactive=true --unlock-password-stdin=true --output=json`
+- `--non-interactive=true --assume-yes=true --output=json`
+
+### Commands
+
+For paged read commands such as `show-all-messages`, `show-folder-messages`, `list-contacts`, and `show-contact-messages`:
+- `-s` / `--page-size` controls only the page size
+- `-l` / `--limit` controls the total number of returned records
+- if `-l` is omitted, the command uses its default total limit
+- paged result `meta` can include fields such as `header`, `returned`, and `hasMore`
+
+Local reproducible coverage:
+- `init`
+- `reset`
+- `add-account -t dec`
+- `list-accounts`
+- `list-folders`
+- `send`
+- `sync-folder`
+- `show-all-messages`
+- `show-message`
+- `delete-message`
+- `show-folder-messages`
+- `list-contacts`
+- `show-contact-messages` if a contact is available
+
+Optional/manual coverage:
+- `add-account -t email`
+- `add-account -t proton`
+- provider-specific sync and message flows for Gmail, Outlook, Proton, or IMAP/SMTP accounts
+- `restore`
+- `import`
+
+## Standard test environment
+
+Create one dedicated working directory for the whole scenario.
+
+Use that working directory for scenario data such as the local vault and database.
+If you preset startup flags in `appsettings.json`, place that file next to `eppie-console`, not in the scenario working directory.
+Use an isolated temporary directory for disposable or destructive scenarios.
+
+Examples:
+- Windows: `C:\temp\eppie-test-001`
+- Linux: `/tmp/eppie-test-001`
+
+Run every command in the scenario with that directory as the process working directory.
+
+Example workflow:
+- create `C:\temp\eppie-run-001`
+- run `--non-interactive=true init` with `WorkingDirectory = C:\temp\eppie-run-001`
+- run `list-accounts`, `show-all-messages`, `reset`, and other checks with the same working directory
+- delete the folder when finished
+
+Short PowerShell example:
+
+```powershell
+$workDir = Join-Path $env:TEMP "eppie-run-001"
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+Push-Location $workDir
+
+# run eppie-console commands here
+
+Pop-Location
+Remove-Item $workDir -Recurse -Force
+```
+
+Short Linux / bash example:
+
+```sh
+workDir="/tmp/eppie-run-001"
+mkdir -p "$workDir"
+cd "$workDir"
+
+# run eppie-console commands here
+
+cd /
+rm -rf "$workDir"
+```
+
+## Baseline local scenario
+
+This is the main scenario that should run first.
+
+### 1. Initialize a fresh vault
+Command:
+- `--non-interactive=true --output=json init`
+
+`stdin`:
+1. vault password
+
+Expected result:
+- `type = status`
+- `code = initialized`
+- `data.seedPhrase` is a non-empty array
+
+### 2. Verify locked command warning without `--unlock-password-stdin=true`
+Command:
+- `--non-interactive=true --output=json list-accounts`
+
+`stdin`:
+- none
+
+Expected result:
+- `type = warning`
+- `code = startupCommandRequiresUnlockPasswordFromStandardInput`
+
+### 3. Verify invalid password handling
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json list-accounts`
+
+`stdin`:
+1. wrong password
+
+Expected result:
+- `type = warning`
+- `code = invalidPassword`
+
+### 4. List accounts in a fresh vault
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json list-accounts`
+
+`stdin`:
+1. vault password
+
+Expected result:
+- `type = result`
+- `code = accounts`
+- `data` is an empty array
+- `meta = null`
+
+### 5. Add a DEC account
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t dec`
+
+`stdin`:
+1. vault password
+
+Expected result:
+- `type = result`
+- `code = accountAdded`
+- `data.address` is non-empty
+- `data.accountType = Dec`
+- `meta = null`
+
+Store the returned `data.address` as `<dec-address>`.
+
+### 6. List accounts after account creation
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json list-accounts`
+
+`stdin`:
+1. vault password
+
+Expected result:
+- `type = result`
+- `code = accounts`
+- `data` contains at least one account
+- one account address matches `<dec-address>`
+- `data[0].accountType = Dec`
+
+### 6a. List folders for the account
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json list-folders -a <dec-address>`
+
+`stdin`:
+1. vault password
+
+Expected result:
+- `type = result`
+- `code = folders`
+- `data` is an array
+- `meta.account = <dec-address>`
+
+If one folder is available, store:
+- `<folder-name>` from a suitable item such as the one whose `roles` contains `inbox`; otherwise keep using `Inbox` only if it is explicitly present in the returned list
+
+### 7. Send a message to the DEC account itself
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json send -s <dec-address> -r <dec-address> -t "Hello from automation"`
+
+`stdin` order:
+1. vault password
+2. `Hello from automation`
+3. `Second body line`
+4. close `stdin`
+
+Expected result:
+- `type = status`
+- `code = messageSent`
+- `data.from = <dec-address>`
+- `data.to = <dec-address>`
+- `data.subject = Hello from automation`
+
+Notes:
+- In `--non-interactive=true` mode, `send` reads the body until end-of-stream.
+
+### 7a. Synchronize the relevant folder before validating newly arrived messages
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json sync-folder -a <dec-address> -f <folder-name>`
+
+`stdin`:
+1. vault password
+
+Expected result:
+- `type = status`
+- `code = folderSynced`
+
+If the current account type or folder does not support a meaningful sync in the local scenario, record the observed result and continue.
+
+### 8. Read recent messages after synchronization
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json show-all-messages -s 5 -l 5`
+
+`stdin`:
+1. vault password
+
+Expected result:
+- `type = result`
+- `code = messages`
+- `data` is an array
+- `meta.header` may be `All messages:`
+- `meta.returned` is a non-negative integer
+- `meta.hasMore` is a boolean
+
+If at least one message is present, also validate:
+- `data[0].to` is an array
+- `data[0].from` is an array
+
+If at least one message is present, store:
+- `<message-id>` from `data[0].id`
+- `<message-pk>` from `data[0].pk`
+
+### 9. Read one message
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json show-message -a <dec-address> -f Inbox -i <message-id> -k <message-pk>`
+
+`stdin`:
+1. vault password
+
+Run this step only if step 8 returned a message item.
+
+Expected result:
+- `type = result`
+- `code = message`
+- `data.id = <message-id>`
+- `data.pk = <message-pk>`
+- `data.to` is an array
+- `data.from` is an array
+
+### 10. Read one folder
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json show-folder-messages -a <dec-address> -f <folder-name> -s 5 -l 5`
+
+`stdin`:
+1. vault password
+
+Expected result:
+- `type = result`
+- `code = messages`
+- `meta.returned` is a non-negative integer
+- `meta.hasMore` is a boolean
+
+### 10a. Delete one message
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json delete-message -a <dec-address> -f <folder-name> -i <message-id> -k <message-pk>`
+
+`stdin`:
+1. vault password
+
+Run this step only if step 8 returned a message item.
+
+Expected result:
+- `type = status`
+- `code = messageDeleted`
+- `data.account = <dec-address>`
+- `data.folder = <folder-name>`
+- `data.id = <message-id>`
+- `data.pk = <message-pk>`
+
+Recommended follow-up validation:
+- run `show-folder-messages` again for `<folder-name>`
+- verify the deleted message no longer appears in that folder result
+
+Notes:
+- when deleting from any folder other than `Trash`, the message should move to `Trash`
+- when deleting from `Trash`, the message should be removed permanently
+- validate both stages if the scenario has a usable `Trash` folder
+
+### 11. List contacts
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json list-contacts -s 10 -l 10`
+
+`stdin`:
+1. vault password
+
+Expected result:
+- `type = result`
+- `code = contacts`
+- `data` is an array
+
+If one contact is available, store `<contact-address>` from the first item.
+
+### 12. Read messages for a contact
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json show-contact-messages -c <contact-address> -s 10 -l 10`
+
+`stdin`:
+1. vault password
+
+Run this step only if step 11 returned a contact.
+
+Expected result:
+- `type = result`
+- `code = messages`
+- `meta.returned` is a non-negative integer
+- `meta.hasMore` is a boolean
+
+### 13. Reset without `--assume-yes=true` to validate warning behavior
+Command:
+- `--non-interactive=true --output=json reset`
+
+`stdin`:
+- none
+
+Expected result:
+- `type = warning`
+- `code = commandRequiresAssumeYesInNonInteractiveMode`
+
+### 14. Reset with `--assume-yes=true`
+Command:
+- `--non-interactive=true --assume-yes=true --output=json reset`
+
+`stdin`:
+- none
+
+Expected result:
+- `type = status`
+- `code = reset`
+
+### 15. Post-reset note
+If post-reset validation is needed, use a suitable non-interactive command whose behavior explicitly documents the expected uninitialized result.
+
+## Text-output spot checks
+
+In addition to the JSON scenario, validate a small text-mode subset.
+
+Recommended checks:
+- `--non-interactive=true --assume-yes=true reset`
+- `--non-interactive=true --unlock-password-stdin=true add-account -t dec`
+- `--non-interactive=true --unlock-password-stdin=true send -s <sender> -r <receiver> -t "<subject>"`
+
+Expected text samples:
+- `The application has just been reset.`
+- `Account <generated-address> added (Dec).`
+- `Message sent from <sender> to <receiver>. Subject: <subject>`
+
+## Negative tests
+
+### Empty body for `send`
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json send -s <dec-address> -r <dec-address> -t "Empty body"`
+
+`stdin` order:
+1. vault password
+2. close `stdin` immediately, providing no body lines
+
+Expected result:
+- `type = status`
+- `code = messageSent`
+- `data.subject = Empty body`
+
+Note:
+- in `--non-interactive=true` mode, end-of-stream is the message body terminator
+- closing `stdin` immediately sends the message with an empty body
+
+### Unknown sender account
+Command:
+- `--non-interactive=true --unlock-password-stdin=true --output=json send -s missing@eppie -r missing@eppie -t "Missing account"`
+
+`stdin` order:
+1. vault password
+2. message body
+3. close `stdin`
+
+Expected result:
+- `type = error`
+- `code = unhandledException`
+- `data.exceptionType = Tuvi.Core.Entities.AccountIsNotExistInDatabaseException`
+- `stdout` remains valid JSON
+- `stderr` does not prepend a stack trace before the JSON response in this mode
+
+### Unsupported interactive-only behavior in `--non-interactive=true`
+When a command path still requires interactive selection or confirmation, expect either:
+- a structured warning, or
+- a structured error such as `nonInteractiveOperationNotSupported`
+
+## Optional provider-specific scenarios
+
+These scenarios are useful, but may require manual setup, secrets, browser auth, or live network access.
+
+### Add regular email account
+Command family:
+- `add-account -t email ...`
+
+Validate:
+- explicit server settings,
+- login/password handling,
+- account appears in `list-accounts`,
+- `sync-folder` returns expected status,
+- messages can be listed and opened.
+
+### Add Proton account
+Command family:
+- `add-account -t proton --input-json-stdin ...`
+
+Validate:
+- authorization flow,
+- account creation result,
+- folder sync,
+- message listing.
+
+Recommended automation pattern:
+- `--non-interactive=true --unlock-password-stdin=true --output=json add-account -t proton --input-json-stdin`
+
+`stdin` shape:
+1. vault password on the first line if `--unlock-password-stdin=true` is used
+2. the remaining standard input as a JSON object
+
+Recommended JSON object fields:
+- `email` — required
+- `accountPassword` — required
+- `mailboxPassword` — required only if the Proton flow requests it
+- `twoFactorCode` — required only if the Proton flow requests it
+
+Recommended negative coverage:
+- invalid JSON returns:
+  - `type = error`
+  - `code = structuredStandardInputInvalidJson`
+- missing required property such as `email` returns:
+  - `type = error`
+  - `code = structuredStandardInputMissingProperty`
+  - `data.propertyName = email`
+
+Automation notes:
+- do not put Proton secrets in command-line arguments
+- verify that the JSON response remains parseable on `stdout` for both success and structured error cases
+- use `list-folders` before folder-specific commands so provider-specific names such as `All Sent` are discovered instead of guessed
+- use `sync-folder` before validating newly arrived messages
+
+### Restore
+Command family:
+- `restore ...`
+
+Validate:
+- reset-or-confirm behavior if local data already exists,
+- restore path handling,
+- restored account availability,
+- post-restore `list-accounts` / message access.
+
+### Import
+Command family:
+- `import ...`
+
+Validate:
+- valid file path,
+- invalid file path,
+- post-import behavior of dependent operations.
+
+## Agent report template
+
+For each run, record:
+- executable path
+- platform: Windows / Linux / macOS
+- shell: PowerShell / bash
+- working directory
+- command line
+- exact `stdin` shape
+- raw output
+- raw stderr output
+- parsed JSON `type`
+- parsed JSON `code`
+- pass/fail verdict
+- notes about deviations from documentation
+
+## Pass criteria
+
+A test run is successful when:
+- all mandatory local steps execute,
+- expected JSON envelopes match documented behavior,
+- `sync-folder` is used before validating newly arrived messages,
+- destructive warnings and unlock-password warnings are observed where expected,
+- `send` works with multi-line body terminated by end-of-stream,
+- `delete-message` returns `messageDeleted`, removes the message from the original folder result, and supports the expected two-step Trash flow,
+- reset completes successfully and any follow-up verification uses a documented non-interactive check,
+- no undocumented regressions are observed.
+
+## Cleanup
+
+After the scenario:
+- run `--non-interactive=true --assume-yes=true reset` if needed,
+- delete the isolated working directory,
+- do not reuse the same vault directory for unrelated scenarios.


### PR DESCRIPTION
# Description

- Introduce detailed agent skill and test plan docs for eppie-console
- Document normative CLI usage patterns for automation and CI/CD
- Clarify non-interactive mode, stdin contracts, and error handling
- Update CLI command docs for pagination and automation flags
- Improve guidance for destructive and scripted workflows

These changes make Eppie-CLI easier to integrate with autonomous agents, CI pipelines, and reproducible test scenarios.

## Related issue

<!--Please add the related issue link(s) below.-->
- Eppie-io/Eppie-CLI#524

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [x] Doc update

## Needs Follow Up Actions

- [ ] New release
